### PR TITLE
Add check for worker timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cluster-scheduler",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Holds an in-memory queue for scheduling tasks to be delegated to cluster workers",
   "engines": {
     "node": ">=6.0.0"

--- a/src/js/scheduler.js
+++ b/src/js/scheduler.js
@@ -167,12 +167,12 @@ class Scheduler {
   }
 
   respawnWorkers() {
-    // Kill workers after timeout exceeded
-    if (this.workerTimeout) {
+    // Kill workers after timeout exceeded, only if the queue is nonempty
+    if (!this.queue.empty() && this.workerTimeout) {
       const now = Date.now();
       let totalKilled = 0;
       workers.forEach(w => {
-        if (now - w.timeStarted >= this.workerTimeout) {
+        if (w.timeStarted && now - w.timeStarted >= this.workerTimeout) {
           logger.info(`Killing worker on PID ${w.pid}`);
           w.kill();
           totalKilled++;


### PR DESCRIPTION
This PR adds two checks for respawning "dead" workers:
1. Checking that a worker has ever processed a job (`null` value for `timeStarted`), and
2. Checking that the job queue is nonempty, so that we don't respawn workers when there are no jobs to process