### PR TITLE
Adds lazy mode for scheduler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cluster-scheduler",
-  "version": "1.3.2",
-  "description": "Holds an in-memory queue for scheduling tasks to be delegated to cluster workers",
+  "version": "1.4.0",
+  "description": "Holds an in-memory queue for scheduling tasks to be delegated to cluster workers.",
   "engines": {
     "node": ">=6.0.0"
   },


### PR DESCRIPTION
This PR adds a lazy mode to the scheduler. In this mode, no workers are started upon creating the `Scheduler`. When a job is detected on the queue, a new worker starts (still subject to  a maximum of `Scheduler.numWorkers`).